### PR TITLE
Correct typo in jh7110.dtsi

### DIFF
--- a/u-boot/arch/riscv/dts/jh7110.dtsi
+++ b/u-boot/arch/riscv/dts/jh7110.dtsi
@@ -380,7 +380,7 @@
 				reg-names = "otg", "xhci", "dev";
 				interrupts = <108>, <109>, <110>;
 				interrupt-names = "host", "peripheral", "otg";
-				phy-names = "cdns3,usb3-phy", "cnds3,usb2-phy";
+				phy-names = "cdns3,usb3-phy", "cdns3,usb2-phy";
 				maximum-speed = "super-speed";
 			};
 		};


### PR DESCRIPTION
Correct "cnds3" typo this should be "cdns3".